### PR TITLE
Attempt to fix error 'binary' not supported on this platform

### DIFF
--- a/.github/workflows/deploy_bookdown.yml
+++ b/.github/workflows/deploy_bookdown.yml
@@ -19,8 +19,8 @@ jobs:
       - name: Install pandoc
         uses: r-lib/actions/setup-pandoc@v2
       - name: Install rmarkdown
+      #options(pkgType = "binary")
         run: |
-          options(pkgType = "binary")
           options(install.packages.check.source = "no")
           install.packages(c("rmarkdown","bookdown", "tidyverse", "psych", "palmerpenguins", "ggbeeswarm", "ggpubr", "tinytex"))
           tinytex::install_tinytex()


### PR DESCRIPTION
Probably caused by switch from runs-on: macOS-latest to runs-on: ubuntu-latest in deploy_bookdown.yml